### PR TITLE
Bump Requires at least value to 3.6.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WordPress Importer ===
 Contributors: wordpressdotorg
 Tags: importer, wordpress
-Requires at least: 3.0
+Requires at least: 3.6
 Tested up to: 4.6
 Stable tag: 0.6.3
 License: GPLv2 or later


### PR DESCRIPTION
c65aedcf379f2b184eb52dc7fac0fa1b22f4a2b6 added `wp_slash()` which is not available before WordPress 3.6.